### PR TITLE
Files module also handles Trim Galore paired-end input

### DIFF
--- a/nf_bismark
+++ b/nf_bismark
@@ -17,7 +17,7 @@ genome = getGenome(params.genome)
 include BISMARK                                from './nf_modules/bismark.mod.nf'   params(genome: genome)
 
 file_ch = makeFilesChannel(args)
-
+// file_ch.view()
 workflow {
     main:
         BISMARK(file_ch, params.outdir, params.bismark_args, params.verbose)

--- a/nf_modules/bismark.mod.nf
+++ b/nf_modules/bismark.mod.nf
@@ -51,10 +51,14 @@ process BISMARK {
 		}
 
 		index = "--genome " + params.genome["bismark"]
-		
+
+		// add Genome build to output name. Currently only using Bowtie 2
+		bismark_name = name + "_" + params.genome["name"] + "_bismark_bt2"
+		// println ("Output basename: $bismark_name")
+
 		"""
 		module load bismark
-		bismark --parallel $cores $index $bismark_options $readString
+		bismark --parallel $cores --basename $bismark_name $index $bismark_options $readString
 		"""
 
 }

--- a/nf_modules/files.mod.nf
+++ b/nf_modules/files.mod.nf
@@ -29,19 +29,49 @@ def getFileBaseNames(fileList) {
             }
         }
         else{
-            matcher = s =~ /^(.*)_(R?[1234]).(fastq|fq).gz$/
 
-            if (matcher.matches()) {
-                if (! baseNames.containsKey(matcher[0][1])) {
-                    baseNames[matcher[0][1]] = []
-                }
-                baseNames[matcher[0][1]].add(matcher[0][2])
-            }
-            else {
-                matcher = s =~ /^(.*).(fastq|fq).gz$/
+            // let's make a distinction for paired-end files already trimmed with Trim Galore
+            // Paired-end files trimmed with Trim Galore follow the folling pattern:
+            // lane1_TGGTTGTT_small_test_L001_R1_val_1.fq.gz
+            // lane1_TGGTTGTT_small_test_L001_R3_val_2.fq.gz
 
+            if (s =~ /_val_/){
+                // println ("Input file '$s' looks like a Trim Galore paired-end file")
+                matcher = s =~ /^(.*)_(R?[1234])_val_[12].(fastq|fq).gz$/
+                // in the above example, this would identify the following basename:
+                // lane1_TGGTTGTT_small_test_L001
+                // println (matcher[0])
                 if (matcher.matches()) {
-                    bareFiles.add(matcher[0][1])
+                    if (! baseNames.containsKey(matcher[0][1])) {
+                        baseNames[matcher[0][1]] = []
+                    }
+                    baseNames[matcher[0][1]].add(matcher[0][2])
+                }
+                else {
+                    matcher = s =~ /^(.*).(fastq|fq).gz$/
+
+                    if (matcher.matches()) {
+                        bareFiles.add(matcher[0][1])
+                    }
+                }
+            
+            }
+            else{ // not Trim Galore processed
+                matcher = s =~ /^(.*)_(R?[1234]).(fastq|fq).gz$/
+
+                // println (matcher[0])
+                if (matcher.matches()) {
+                    if (! baseNames.containsKey(matcher[0][1])) {
+                        baseNames[matcher[0][1]] = []
+                    }
+                    baseNames[matcher[0][1]].add(matcher[0][2])
+                }
+                else {
+                    matcher = s =~ /^(.*).(fastq|fq).gz$/
+
+                    if (matcher.matches()) {
+                        bareFiles.add(matcher[0][1])
+                    }
                 }
             }
         }


### PR DESCRIPTION
Had to add an additional regex for Trim Galore input files as paired-end files would have been processed in single-end mode only.