### PR TITLE
Added list genome functionality to all pipelines

### DIFF
--- a/nf_bismark
+++ b/nf_bismark
@@ -7,12 +7,23 @@ params.verbose = false
 params.bismark_args = ''
 params.single_end = false // default mode is auto-detect. NOTE: params are handed over automatically
 
+params.list_genomes = false;
+if (params.list_genomes){
+    println ("[WORKLFOW] List genomes selected")
+}
+
 if (params.verbose){
     println ("[WORKFLOW] BISMARK ARGS ARE: "       + params.bismark_args)
 }
 
 include { makeFilesChannel; getFileBaseNames } from './nf_modules/files.mod.nf'
 include getGenome                              from './nf_modules/genomes.mod.nf'
+include listGenomes                            from './nf_modules/genomes.mod.nf'
+
+if (params.list_genomes){
+    listGenomes()  // this lists all available genomes, and exits
+}
+
 genome = getGenome(params.genome)
 include BISMARK                                from './nf_modules/bismark.mod.nf'   params(genome: genome)
 

--- a/nf_bisulfite_PBAT
+++ b/nf_bisulfite_PBAT
@@ -19,6 +19,11 @@ params.bismark2summary_args = ''
 params.bismark2report_args= ''
 params.multiqc_args = ''
 
+params.list_genomes = false;
+if (params.list_genomes){
+    println ("[WORKLFOW] List genomes selected")
+}
+
 if (params.verbose){
     println ("[WORKFLOW] FASTQC ARGS: "           + params.fastqc_args)
     println ("[WORKFLOW] FASTQ SCREEN ARGS ARE: " + params.fastq_screen_args)
@@ -30,6 +35,12 @@ if (params.verbose){
 
 include { makeFilesChannel; getFileBaseNames } from './nf_modules/files.mod.nf'
 include getGenome                              from './nf_modules/genomes.mod.nf'
+include listGenomes                            from './nf_modules/genomes.mod.nf'
+
+if (params.list_genomes){
+    listGenomes()  // this lists all available genomes, and exits
+}
+
 genome = getGenome(params.genome)
 
 include FASTQC                                 from './nf_modules/fastqc.mod.nf'                         

--- a/nf_bisulfite_RRBS
+++ b/nf_bisulfite_RRBS
@@ -15,6 +15,11 @@ params.bismark2summary_args = ''
 params.bismark2report_args= ''
 params.multiqc_args = ''
 
+params.list_genomes = false;
+if (params.list_genomes){
+    println ("[WORKLFOW] List genomes selected")
+}
+
 if (params.verbose){
     println ("[WORKFLOW] FASTQC ARGS: "           + params.fastqc_args)
     println ("[WORKFLOW] FASTQ SCREEN ARGS ARE: " + params.fastq_screen_args)
@@ -24,6 +29,12 @@ if (params.verbose){
 
 include { makeFilesChannel; getFileBaseNames } from './nf_modules/files.mod.nf'
 include getGenome                              from './nf_modules/genomes.mod.nf'
+include listGenomes                            from './nf_modules/genomes.mod.nf'
+
+if (params.list_genomes){
+    listGenomes()  // this lists all available genomes, and exits
+}
+
 genome = getGenome(params.genome)
 
 include FASTQC                                 from './nf_modules/fastqc.mod.nf' 

--- a/nf_bisulfite_RRBS_clock
+++ b/nf_bisulfite_RRBS_clock
@@ -16,6 +16,11 @@ params.bismark2summary_args = ''
 params.bismark2report_args= ''
 params.multiqc_args = ''
 
+params.list_genomes = false;
+if (params.list_genomes){
+    println ("[WORKLFOW] List genomes selected")
+}
+
 if (params.verbose){
     println ("[WORKFLOW] FASTQC ARGS: "           + params.fastqc_args)
     println ("[WORKFLOW] FASTQ SCREEN ARGS ARE: " + params.fastq_screen_args)
@@ -27,6 +32,12 @@ if (params.verbose){
 
 include { makeFilesChannel; getFileBaseNames }  from './nf_modules/files.mod.nf'
 include getGenome                               from './nf_modules/genomes.mod.nf'
+include listGenomes                             from './nf_modules/genomes.mod.nf'
+
+if (params.list_genomes){
+    listGenomes()  // this lists all available genomes, and exits
+}
+
 genome = getGenome(params.genome)
 
 include FASTQC                                  from './nf_modules/fastqc.mod.nf' 

--- a/nf_bisulfite_WGBS
+++ b/nf_bisulfite_WGBS
@@ -8,6 +8,11 @@ params.genome = ""
 params.verbose = false
 params.single_end = false  // default mode is auto-detect. NOTE: params are automatically handed over 
 
+params.list_genomes = false;
+if (params.list_genomes){
+    println ("[WORKLFOW] List genomes selected")
+}
+
 params.fastqc_args = ''
 params.fastq_screen_args = ''
 params.trim_galore_args = ''
@@ -30,6 +35,12 @@ if (params.verbose){
 
 include { makeFilesChannel; getFileBaseNames } from './nf_modules/files.mod.nf'
 include getGenome                              from './nf_modules/genomes.mod.nf'
+include listGenomes                            from './nf_modules/genomes.mod.nf'
+
+if (params.list_genomes){
+    listGenomes()  // this lists all available genomes, and exits
+}
+
 genome = getGenome(params.genome)
 
 include FASTQC                                 from './nf_modules/fastqc.mod.nf'                         

--- a/nf_bisulfite_scBSseq
+++ b/nf_bisulfite_scBSseq
@@ -18,6 +18,11 @@ params.bismark2summary_args = ''
 params.bismark2report_args= ''
 params.multiqc_args = ''
 
+params.list_genomes = false;
+if (params.list_genomes){
+    println ("[WORKLFOW] List genomes selected")
+}
+
 if (params.verbose){
     println ("[WORKFLOW] FASTQC ARGS: "           + params.fastqc_args)
     println ("[WORKFLOW] FASTQ SCREEN ARGS ARE: " + params.fastq_screen_args)
@@ -29,6 +34,12 @@ if (params.verbose){
 
 include { makeFilesChannel; getFileBaseNames }  from './nf_modules/files.mod.nf'
 include getGenome                               from './nf_modules/genomes.mod.nf'
+include listGenomes                            from './nf_modules/genomes.mod.nf'
+
+if (params.list_genomes){
+    listGenomes()  // this lists all available genomes, and exits
+}
+
 genome = getGenome(params.genome)
 
 include FASTQC                                  from './nf_modules/fastqc.mod.nf'                        

--- a/nf_bisulfite_scNMT
+++ b/nf_bisulfite_scNMT
@@ -19,6 +19,11 @@ params.bismark2summary_args = ''
 params.bismark2report_args= ''
 params.multiqc_args = ''
 
+params.list_genomes = false;
+if (params.list_genomes){
+    println ("[WORKLFOW] List genomes selected")
+}
+
 if (params.verbose){
     println ("[WORKFLOW] FASTQC ARGS: "           + params.fastqc_args)
     println ("[WORKFLOW] FASTQ SCREEN ARGS ARE: " + params.fastq_screen_args)
@@ -31,6 +36,12 @@ if (params.verbose){
 
 include { makeFilesChannel; getFileBaseNames }      from './nf_modules/files.mod.nf'
 include getGenome                                   from './nf_modules/genomes.mod.nf'
+include listGenomes                                 from './nf_modules/genomes.mod.nf'
+
+if (params.list_genomes){
+    listGenomes()  // this lists all available genomes, and exits
+}
+
 genome = getGenome(params.genome)
 
 include FASTQC                                      from './nf_modules/fastqc.mod.nf'                        

--- a/nf_bowtie2
+++ b/nf_bowtie2
@@ -9,7 +9,7 @@ params.single_end = false  // default mode is auto-detect. NOTE: params are hand
 
 params.list_genomes = false;
 if (params.list_genomes){
-    println ("List genomes selected [WORKLFOW]")
+    println ("[WORKLFOW] List genomes selected")
 }
 
 if (params.verbose){

--- a/nf_bowtie2
+++ b/nf_bowtie2
@@ -7,6 +7,10 @@ params.bowtie2_args = ''
 params.verbose = false
 params.single_end = false  // default mode is auto-detect. NOTE: params are handed over automatically 
 
+params.list_genomes = false;
+if (params.list_genomes){
+    println ("List genomes selected [WORKLFOW]")
+}
 
 if (params.verbose){
     println ("[WORKFLOW] BOWTIE2 ARGS: "      + params.bowtie2_args)
@@ -14,10 +18,18 @@ if (params.verbose){
 
 include { makeFilesChannel; getFileBaseNames } from './nf_modules/files.mod.nf'
 include getGenome                              from './nf_modules/genomes.mod.nf'
+include listGenomes                            from './nf_modules/genomes.mod.nf'
+
+if (params.list_genomes){
+    listGenomes()  // this lists all available genomes, and exits
+}
+
 genome = getGenome(params.genome)
 
 include BOWTIE2 from './nf_modules/bowtie2.mod.nf'   params(genome: genome)
+
 file_ch = makeFilesChannel(args)
+
 
 workflow {
 

--- a/nf_chipseq
+++ b/nf_chipseq
@@ -14,6 +14,12 @@ params.trim_galore_args = ''
 params.bowtie2_args = ''
 params.multiqc_args = ''
 
+
+params.list_genomes = false;
+if (params.list_genomes){
+    println ("[WORKLFOW] List genomes selected")
+}
+
 if (params.verbose){
     println ("[WORKFLOW] FASTQC ARGS: "           + params.fastqc_args)
     println ("[WORKFLOW] FASTQ SCREEN ARGS ARE: " + params.fastq_screen_args)
@@ -24,6 +30,11 @@ if (params.verbose){
 
 include { makeFilesChannel; getFileBaseNames } from './nf_modules/files.mod.nf'
 include getGenome from './nf_modules/genomes.mod.nf'
+include listGenomes                            from './nf_modules/genomes.mod.nf'
+
+if (params.list_genomes){
+    listGenomes()  // this lists all available genomes, and exits
+}
 genome = getGenome(params.genome)
 
 include FASTQC            from './nf_modules/fastqc.mod.nf'

--- a/nf_hisat2
+++ b/nf_hisat2
@@ -7,12 +7,23 @@ params.verbose = false
 params.hisat2_args = ''
 params.single_end = false  // default mode is auto-detect. NOTE: params are handed over automatically
 
+params.list_genomes = false;
+if (params.list_genomes){
+    println ("List genomes selected [WORKLFOW]")
+}
+
 if (params.verbose){
     println ("[WORKFLOW] HISAT2 ARGS ARE: "       + params.hisat2_args)
 }
 
 include { makeFilesChannel; getFileBaseNames } from './nf_modules/files.mod.nf'
 include getGenome                              from './nf_modules/genomes.mod.nf'
+include listGenomes                            from './nf_modules/genomes.mod.nf'
+
+if (params.list_genomes){
+    listGenomes()  // this lists all available genomes, and exits
+}
+
 genome = getGenome(params.genome)
 include HISAT2                                 from './nf_modules/hisat2.mod.nf' params(genome: genome)
 

--- a/nf_modules/genomes.mod.nf
+++ b/nf_modules/genomes.mod.nf
@@ -4,14 +4,24 @@ nextflow.preview.dsl=2
 
 def getGenome(name) {
 
-    // Find a file with the same name as the genome
-    // in our genomes.d directory
+    // Find a file with the same name as the genome in our genomes.d directory
 
     scriptDir = workflow.projectDir
+    
+    // die gracefully if the user specified an incorrect genome
+    def fileName = scriptDir.toString() + "/genomes.d/" + name + ".genome"
+    def testFile = new File(fileName)
+    if (!testFile.exists()) {
+        println("\nFile >>$fileName<< does not exist. Listing available genomes...\n")
+        listGenomes()
+    }   
+    else { 
+        // println ("File $fileName exists.")
+    }
 
-    genomeFH = new File(scriptDir.toString()+"/genomes.d/"+name+".genome").newInputStream()
+    genomeFH = new File (fileName).newInputStream()
 
-    genomeValues = ["name" : name]
+    genomeValues = [:]  // initialising map. name is also part of each .genome file
 
     genomeFH.eachLine {
         sections =  it.split("\\s+",2)
@@ -20,5 +30,33 @@ def getGenome(name) {
 
     return genomeValues
 
+}
+
+def listGenomes(){
+    
+    println ("These genomes are currently available to choose from:")
+    println ("=====================================================")
+    scriptDir = workflow.projectDir + "/genomes.d/"
+    // println (scriptDir) // last slash is consumed
+    allFiles = scriptDir.list()
+    
+    for( def file : allFiles.sort() ) {
+        
+        if( file =~ /.genome$/){
+
+            genomeFH = new File(scriptDir.toString() + "/$file").newInputStream()
+            name = file.replaceFirst(/.genome/, "")
+        
+            println (name)
+            genomeFH.eachLine {
+                if (params.verbose){
+                    println ("\t$it")
+                }
+            }
+        }
+    }
+    println ("\nTo see this list of available genomes with more detailed information about paths and indexes,\nplease re-run the command including '--list_genomes --verbose'\n\n")
+
+    System.exit(1)
 }
 

--- a/nf_rnaseq
+++ b/nf_rnaseq
@@ -12,6 +12,10 @@ params.trim_galore_args = ''
 params.hisat2_args = ''
 params.multiqc_args = ''
 
+params.list_genomes = false;
+if (params.list_genomes){
+    println ("[WORKLFOW] List genomes selected")
+}
 
 if (params.verbose){
     println ("[WORKFLOW] FASTQC ARGS: "           + params.fastqc_args)
@@ -23,6 +27,11 @@ if (params.verbose){
 
 include { makeFilesChannel; getFileBaseNames } from './nf_modules/files.mod.nf'
 include getGenome    from './nf_modules/genomes.mod.nf'
+include listGenomes  from './nf_modules/genomes.mod.nf'
+
+if (params.list_genomes){
+    listGenomes()  // this lists all available genomes, and exits
+}
 genome = getGenome(params.genome)
 
 include FASTQC       from './nf_modules/fastqc.mod.nf'


### PR DESCRIPTION
For all pipelines involving a genome one can now use `--list_genomes` to get a list of available genomes (just the genome build names). For more detailed information on each genome, i.e. FastA, HISAT2, Bowtie2 indices etc.), use `--list_genomes --verbose`.

Finally, if a genome build was entered incorrectly, a list of available genomes is printed and Nextflow exits.