### PR TITLE
Added dynamic retries with backoff for several modules

### DIFF
--- a/nextflow.config
+++ b/nextflow.config
@@ -9,8 +9,7 @@ process {
 
     executor = 'slurm'
     memory = 5.GB
-    cpus = 2
-
+    cpus = 1
 
     withLabel: bigMem {
         memory = 20.GB
@@ -32,22 +31,8 @@ process {
      	cpus = 4
     }
    
-   
- 
-    //withName: MULTIQC{
-     //   cpus = 2
-        // module  multiqc TODO: Not working at present
-    //}
-    withName: FASTQ_SCREEN{
-        cpus = 4
-        memory = 40.GB
-    }
-    withName: TRIM_GALORE{
-       cpus = 4
-       memory = 10.GB
-        // module 
-    }
 }
+
 notification {
     enabled = true
     to = "${USER}@babraham.ac.uk"
@@ -62,9 +47,10 @@ report {
     file = "execution_report.html"
 }
 //trace {
- //   enabled = true
+//   enabled = true
 //    file = "execution_trace.txt"
 //}
+
 // dag {
 //   enabled = true
 //   file = "pipeline_dag.svg"

--- a/nf_bisulfite_PBAT
+++ b/nf_bisulfite_PBAT
@@ -1,5 +1,5 @@
 #!/usr/bin/env nextflow
-nextflow.preview.dsl=2
+nextflow.enable.dsl=2
 
 params.outdir = "."
 params.genome = ""
@@ -34,8 +34,8 @@ if (params.verbose){
 }
 
 include { makeFilesChannel; getFileBaseNames } from './nf_modules/files.mod.nf'
-include getGenome                              from './nf_modules/genomes.mod.nf'
-include listGenomes                            from './nf_modules/genomes.mod.nf'
+include { getGenome }                             from './nf_modules/genomes.mod.nf'
+include { listGenomes }                           from './nf_modules/genomes.mod.nf'
 
 if (params.list_genomes){
     listGenomes()  // this lists all available genomes, and exits
@@ -100,3 +100,20 @@ workflow {
         MULTIQC                          (multiqc_ch, params.outdir, params.multiqc_args, params.verbose)
 }
 
+// Since workflows with very long command lines tend to fail to get rendered at all, I was experimenting with a
+// minimal execution summary report so we at least know what the working directory was...
+workflow.onComplete {
+
+    def msg = """\
+        Pipeline execution summary
+        ---------------------------
+        Completed at: ${workflow.complete}
+        Duration    : ${workflow.duration}
+        Success     : ${workflow.success}
+        workDir     : ${workflow.workDir}
+        exit status : ${workflow.exitStatus}
+        """
+    .stripIndent()
+
+    sendMail(to: "${workflow.userName}@babraham.ac.uk", subject: 'Minimal pipeline execution report', body: msg)
+}

--- a/nf_bisulfite_RRBS
+++ b/nf_bisulfite_RRBS
@@ -1,5 +1,5 @@
 #!/usr/bin/env nextflow
-nextflow.preview.dsl=2
+nextflow.enable.dsl=2
 
 params.outdir = "."
 params.genome = ""
@@ -28,8 +28,8 @@ if (params.verbose){
      println ("[WORKFLOW] BISMARK METHYLATION EXTRACTOR ARGS ARE: " + params.bismark_methylation_extractor_args)}
 
 include { makeFilesChannel; getFileBaseNames } from './nf_modules/files.mod.nf'
-include getGenome                              from './nf_modules/genomes.mod.nf'
-include listGenomes                            from './nf_modules/genomes.mod.nf'
+include { getGenome }                            from './nf_modules/genomes.mod.nf'
+include { listGenomes }                          from './nf_modules/genomes.mod.nf'
 
 if (params.list_genomes){
     listGenomes()  // this lists all available genomes, and exits
@@ -37,21 +37,21 @@ if (params.list_genomes){
 
 genome = getGenome(params.genome)
 
-include FASTQC                                 from './nf_modules/fastqc.mod.nf' 
-include FASTQC as FASTQC2                      from './nf_modules/fastqc.mod.nf'
+include { FASTQC }                                from './nf_modules/fastqc.mod.nf' 
+include { FASTQC as FASTQC2 }                     from './nf_modules/fastqc.mod.nf'
 
-include FASTQ_SCREEN                           from './nf_modules/fastq_screen.mod.nf'   params(bisulfite: '--bisulfite')
-
-// Adding flag for RRBS processing
-include TRIM_GALORE                            from './nf_modules/trim_galore.mod.nf'    params(rrbs: true)
-include BISMARK                                from './nf_modules/bismark.mod.nf'        params(genome: genome)
+include { FASTQ_SCREEN }                          from './nf_modules/fastq_screen.mod.nf'   params(bisulfite: '--bisulfite')
 
 // Adding flag for RRBS processing
-include BISMARK_METHYLATION_EXTRACTOR          from './nf_modules/bismark_methylation_extractor.mod.nf'   params(rrbs: true)
-include BISMARK2REPORT                         from './nf_modules/bismark2report.mod.nf'
-include BISMARK2SUMMARY                        from './nf_modules/bismark2summary.mod.nf'
+include { TRIM_GALORE }                           from './nf_modules/trim_galore.mod.nf'    params(rrbs: true)
+include { BISMARK }                               from './nf_modules/bismark.mod.nf'        params(genome: genome)
 
-include MULTIQC                                from './nf_modules/multiqc.mod.nf' 
+// Adding flag for RRBS processing
+include { BISMARK_METHYLATION_EXTRACTOR }          from './nf_modules/bismark_methylation_extractor.mod.nf'   params(rrbs: true)
+include { BISMARK2REPORT }                        from './nf_modules/bismark2report.mod.nf'
+include { BISMARK2SUMMARY }                       from './nf_modules/bismark2summary.mod.nf'
+
+include { MULTIQC }                               from './nf_modules/multiqc.mod.nf' 
 
 file_ch = makeFilesChannel(args)
 

--- a/nf_bisulfite_RRBS_clock
+++ b/nf_bisulfite_RRBS_clock
@@ -1,5 +1,5 @@
 #!/usr/bin/env nextflow
-nextflow.preview.dsl=2
+nextflow.enable.dsl=2
 
 params.outdir = "."
 params.genome = ""
@@ -31,8 +31,8 @@ if (params.verbose){
 }
 
 include { makeFilesChannel; getFileBaseNames }  from './nf_modules/files.mod.nf'
-include getGenome                               from './nf_modules/genomes.mod.nf'
-include listGenomes                             from './nf_modules/genomes.mod.nf'
+include { getGenome }                              from './nf_modules/genomes.mod.nf'
+include { listGenomes }                             from './nf_modules/genomes.mod.nf'
 
 if (params.list_genomes){
     listGenomes()  // this lists all available genomes, and exits
@@ -40,28 +40,28 @@ if (params.list_genomes){
 
 genome = getGenome(params.genome)
 
-include FASTQC                                  from './nf_modules/fastqc.mod.nf' 
-include FASTQC as FASTQC2                       from './nf_modules/fastqc.mod.nf'
-include FASTQC as FASTQC3                       from './nf_modules/fastqc.mod.nf'
+include { FASTQC }                                 from './nf_modules/fastqc.mod.nf' 
+include { FASTQC as FASTQC2 }                      from './nf_modules/fastqc.mod.nf'
+include { FASTQC as FASTQC3 }                      from './nf_modules/fastqc.mod.nf'
 
 // --bisulfite paramater needs to be re-enabled, but MultiQC is currently broken
-include FASTQ_SCREEN                            from './nf_modules/fastq_screen.mod.nf' params(bisulfite: '--bisulfite')
+include { FASTQ_SCREEN }                           from './nf_modules/fastq_screen.mod.nf' params(bisulfite: '--bisulfite')
 
 // Adding flag for RRBS processing
 // The second trimming step needs to look like this:
 // trim_galore --paired --three_prime_clip_R1 15 --three_prime_clip_R2 15 *.clock_UMI.R1.fq.gz *.clock_UMI.R2.fq.gz
 
-include TRIM_GALORE                             from './nf_modules/trim_galore.mod.nf' params(three_prime_clip_R1: 15, three_prime_clip_R2: 15)
-include TRIM_GALORE as TRIM_CLOCK               from './nf_modules/trim_galore.mod.nf' params(clock: true)
-include BISMARK                                 from './nf_modules/bismark.mod.nf'     params(genome: genome)
-include UMIBAM                                  from './nf_modules/umibam.mod.nf'      params(dual: true)
+include { TRIM_GALORE }                            from './nf_modules/trim_galore.mod.nf' params(three_prime_clip_R1: 15, three_prime_clip_R2: 15)
+include { TRIM_GALORE as TRIM_CLOCK }              from './nf_modules/trim_galore.mod.nf' params(clock: true)
+include { BISMARK }                                from './nf_modules/bismark.mod.nf'     params(genome: genome)
+include { UMIBAM }                                 from './nf_modules/umibam.mod.nf'      params(dual: true)
 
 // Adding flag for RRBS processing
-include BISMARK_METHYLATION_EXTRACTOR           from './nf_modules/bismark_methylation_extractor.mod.nf' params(rrbs: true)
-include BISMARK2REPORT                          from './nf_modules/bismark2report.mod.nf'
-include BISMARK2SUMMARY                         from './nf_modules/bismark2summary.mod.nf'
+include { BISMARK_METHYLATION_EXTRACTOR }           from './nf_modules/bismark_methylation_extractor.mod.nf' params(rrbs: true)
+include { BISMARK2REPORT }                         from './nf_modules/bismark2report.mod.nf'
+include { BISMARK2SUMMARY }                        from './nf_modules/bismark2summary.mod.nf'
 
-include MULTIQC                                 from './nf_modules/multiqc.mod.nf' 
+include { MULTIQC }                                from './nf_modules/multiqc.mod.nf' 
 
 file_ch = makeFilesChannel(args)
 

--- a/nf_bisulfite_WGBS
+++ b/nf_bisulfite_WGBS
@@ -1,7 +1,7 @@
 #!/usr/bin/env nextflow
 
 // Enable modules
-nextflow.preview.dsl=2
+nextflow.enable.dsl=2
 
 params.outdir = "."
 params.genome = ""
@@ -34,8 +34,8 @@ if (params.verbose){
 }
 
 include { makeFilesChannel; getFileBaseNames } from './nf_modules/files.mod.nf'
-include getGenome                              from './nf_modules/genomes.mod.nf'
-include listGenomes                            from './nf_modules/genomes.mod.nf'
+include { getGenome }                              from './nf_modules/genomes.mod.nf'
+include { listGenomes }                            from './nf_modules/genomes.mod.nf'
 
 if (params.list_genomes){
     listGenomes()  // this lists all available genomes, and exits
@@ -43,19 +43,19 @@ if (params.list_genomes){
 
 genome = getGenome(params.genome)
 
-include FASTQC                                 from './nf_modules/fastqc.mod.nf'                         
-include FASTQC as FASTQC2                      from './nf_modules/fastqc.mod.nf'
+include { FASTQC }                                from './nf_modules/fastqc.mod.nf'                         
+include { FASTQC as FASTQC2 }                     from './nf_modules/fastqc.mod.nf'
 
-include FASTQ_SCREEN                           from './nf_modules/fastq_screen.mod.nf'   params(bisulfite: '--bisulfite')
-include TRIM_GALORE                            from './nf_modules/trim_galore.mod.nf'                    
+include { FASTQ_SCREEN }                          from './nf_modules/fastq_screen.mod.nf'   params(bisulfite: '--bisulfite')
+include { TRIM_GALORE }                           from './nf_modules/trim_galore.mod.nf'                    
 
-include BISMARK                                from './nf_modules/bismark.mod.nf'        params(genome: genome)
-include BISMARK_DEDUPLICATION                  from './nf_modules/bismark_deduplication.mod.nf'
-include BISMARK_METHYLATION_EXTRACTOR          from './nf_modules/bismark_methylation_extractor.mod.nf' 
-include BISMARK2REPORT                         from './nf_modules/bismark2report.mod.nf'
-include BISMARK2SUMMARY                        from './nf_modules/bismark2summary.mod.nf'
+include { BISMARK }                               from './nf_modules/bismark.mod.nf'        params(genome: genome)
+include { BISMARK_DEDUPLICATION }                 from './nf_modules/bismark_deduplication.mod.nf'
+include { BISMARK_METHYLATION_EXTRACTOR }         from './nf_modules/bismark_methylation_extractor.mod.nf' 
+include { BISMARK2REPORT }                        from './nf_modules/bismark2report.mod.nf'
+include { BISMARK2SUMMARY }                       from './nf_modules/bismark2summary.mod.nf'
 
-include MULTIQC                                from './nf_modules/multiqc.mod.nf' 
+include { MULTIQC }                               from './nf_modules/multiqc.mod.nf' 
 
 file_ch = makeFilesChannel(args)
 
@@ -93,5 +93,22 @@ workflow {
         BISMARK2REPORT                   (bismark_report_ch, params.outdir, params.bismark2report_args, params.verbose)
         BISMARK2SUMMARY                  (bismark_report_ch, params.outdir, params.bismark2summary_args, params.verbose)
         MULTIQC                          (multiqc_ch, params.outdir, params.multiqc_args, params.verbose)
-   }
+}
 
+// Since workflows with very long command lines tend to fail to get rendered at all, I was experimenting with a
+// minimal execution summary report so we at least know what the working directory was...
+workflow.onComplete {
+
+    def msg = """\
+        Pipeline execution summary
+        ---------------------------
+        Completed at: ${workflow.complete}
+        Duration    : ${workflow.duration}
+        Success     : ${workflow.success}
+        workDir     : ${workflow.workDir}
+        exit status : ${workflow.exitStatus}
+        """
+    .stripIndent()
+
+    sendMail(to: "${workflow.userName}@babraham.ac.uk", subject: 'Minimal pipeline execution report', body: msg)
+}

--- a/nf_bisulfite_scBSseq
+++ b/nf_bisulfite_scBSseq
@@ -1,7 +1,7 @@
 #!/usr/bin/env nextflow
 
 // Enable modules
-nextflow.preview.dsl=2
+nextflow.enable.dsl=2
 
 params.outdir = "."
 params.genome = ""
@@ -33,8 +33,8 @@ if (params.verbose){
 }
 
 include { makeFilesChannel; getFileBaseNames }  from './nf_modules/files.mod.nf'
-include getGenome                               from './nf_modules/genomes.mod.nf'
-include listGenomes                            from './nf_modules/genomes.mod.nf'
+include { getGenome }                               from './nf_modules/genomes.mod.nf'
+include { listGenomes }                           from './nf_modules/genomes.mod.nf'
 
 if (params.list_genomes){
     listGenomes()  // this lists all available genomes, and exits
@@ -42,22 +42,22 @@ if (params.list_genomes){
 
 genome = getGenome(params.genome)
 
-include FASTQC                                  from './nf_modules/fastqc.mod.nf'                        
-include FASTQC as FASTQC2                       from './nf_modules/fastqc.mod.nf'
+include { FASTQC }                                 from './nf_modules/fastqc.mod.nf'                        
+include { FASTQC as FASTQC2 }                      from './nf_modules/fastqc.mod.nf'
 
-include FASTQ_SCREEN                            from './nf_modules/fastq_screen.mod.nf' params(bisulfite: '--bisulfite')
-
-// Adding singlecell flag for scBS-seq processing
-include TRIM_GALORE                             from './nf_modules/trim_galore.mod.nf' params(singlecell: true)
-// Adding singlecell flag for scBS-seq processing
-include BISMARK                                 from './nf_modules/bismark.mod.nf' params(genome: genome, singlecell: true)
-include BISMARK_DEDUPLICATION                   from './nf_modules/bismark_deduplication.mod.nf'
-include BISMARK2REPORT                          from './nf_modules/bismark2report.mod.nf'
-include BISMARK2SUMMARY                         from './nf_modules/bismark2summary.mod.nf'
+include { FASTQ_SCREEN }                           from './nf_modules/fastq_screen.mod.nf' params(bisulfite: '--bisulfite')
 
 // Adding singlecell flag for scBS-seq processing
-include BISMARK_METHYLATION_EXTRACTOR           from './nf_modules/bismark_methylation_extractor.mod.nf'   params(singlecell: true)
-include MULTIQC                                 from './nf_modules/multiqc.mod.nf' 
+include { TRIM_GALORE }                            from './nf_modules/trim_galore.mod.nf' params(singlecell: true)
+// Adding singlecell flag for scBS-seq processing
+include { BISMARK }                                from './nf_modules/bismark.mod.nf' params(genome: genome, singlecell: true)
+include { BISMARK_DEDUPLICATION }                  from './nf_modules/bismark_deduplication.mod.nf'
+include { BISMARK2REPORT }                         from './nf_modules/bismark2report.mod.nf'
+include { BISMARK2SUMMARY }                        from './nf_modules/bismark2summary.mod.nf'
+
+// Adding singlecell flag for scBS-seq processing
+include { BISMARK_METHYLATION_EXTRACTOR }          from './nf_modules/bismark_methylation_extractor.mod.nf'   params(singlecell: true)
+include { MULTIQC }                                from './nf_modules/multiqc.mod.nf' 
 
 file_ch = makeFilesChannel(args)
 
@@ -95,4 +95,22 @@ workflow {
         BISMARK2REPORT                   (bismark_report_ch, params.outdir, params.bismark2report_args, params.verbose)
         BISMARK2SUMMARY                  (bismark_report_ch, params.outdir, params.bismark2summary_args, params.verbose)
         MULTIQC                          (multiqc_ch, params.outdir, params.multiqc_args, params.verbose)
+}
+
+// Since workflows with very long command lines tend to fail to get rendered at all, I was experimenting with a
+// minimal execution summary report so we at least know what the working directory was...
+workflow.onComplete {
+
+    def msg = """\
+        Pipeline execution summary
+        ---------------------------
+        Completed at: ${workflow.complete}
+        Duration    : ${workflow.duration}
+        Success     : ${workflow.success}
+        workDir     : ${workflow.workDir}
+        exit status : ${workflow.exitStatus}
+        """
+    .stripIndent()
+
+    sendMail(to: "${workflow.userName}@babraham.ac.uk", subject: 'Minimal pipeline execution report', body: msg)
 }

--- a/nf_bisulfite_scNMT
+++ b/nf_bisulfite_scNMT
@@ -1,7 +1,5 @@
 #!/usr/bin/env nextflow
-
-// Enable modules
-nextflow.preview.dsl=2
+nextflow.enable.dsl=2
 
 params.outdir = "."
 params.genome = ""
@@ -34,9 +32,9 @@ if (params.verbose){
     println ("[WORKFLOW] BISMARK COVERAGE2CYTOSINE ARGS ARE: "     + params.coverage2cytosine_args)
 }
 
-include { makeFilesChannel; getFileBaseNames }      from './nf_modules/files.mod.nf'
-include getGenome                                   from './nf_modules/genomes.mod.nf'
-include listGenomes                                 from './nf_modules/genomes.mod.nf'
+include { makeFilesChannel; getFileBaseNames }         from './nf_modules/files.mod.nf'
+include { getGenome }                                  from './nf_modules/genomes.mod.nf'
+include { listGenomes }                                from './nf_modules/genomes.mod.nf'
 
 if (params.list_genomes){
     listGenomes()  // this lists all available genomes, and exits
@@ -44,24 +42,24 @@ if (params.list_genomes){
 
 genome = getGenome(params.genome)
 
-include FASTQC                                      from './nf_modules/fastqc.mod.nf'                        
-include FASTQC as FASTQC2                           from './nf_modules/fastqc.mod.nf'
+include { FASTQC }                                     from './nf_modules/fastqc.mod.nf'                        
+include { FASTQC as FASTQC2 }                          from './nf_modules/fastqc.mod.nf'
 
-include FASTQ_SCREEN                                from './nf_modules/fastq_screen.mod.nf' params(bisulfite: '--bisulfite')
-
-// Adding singlecell flag for scBS-seq processing
-include TRIM_GALORE                                 from './nf_modules/trim_galore.mod.nf'  params(singlecell: true)
+include { FASTQ_SCREEN }                               from './nf_modules/fastq_screen.mod.nf' params(bisulfite: '--bisulfite')
 
 // Adding singlecell flag for scBS-seq processing
-include BISMARK                                     from './nf_modules/bismark.mod.nf' params(genome: genome, singlecell: true)
-include BISMARK_DEDUPLICATION                       from './nf_modules/bismark_deduplication.mod.nf'
-include BISMARK2REPORT                              from './nf_modules/bismark2report.mod.nf'
-include BISMARK2SUMMARY                             from './nf_modules/bismark2summary.mod.nf'
+include { TRIM_GALORE }                                from './nf_modules/trim_galore.mod.nf'  params(singlecell: true)
 
 // Adding singlecell flag for scBS-seq processing
-include BISMARK_METHYLATION_EXTRACTOR               from './nf_modules/bismark_methylation_extractor.mod.nf'   params(singlecell: true, nonCG: true)
-include COVERAGE2CYTOSINE                           from './nf_modules/coverage2cytosine.mod.nf' params(nome: true, genome: genome)
-include MULTIQC                                     from './nf_modules/multiqc.mod.nf' 
+include { BISMARK }                                    from './nf_modules/bismark.mod.nf' params(genome: genome, singlecell: true)
+include { BISMARK_DEDUPLICATION }                      from './nf_modules/bismark_deduplication.mod.nf'
+include { BISMARK2REPORT }                             from './nf_modules/bismark2report.mod.nf'
+include { BISMARK2SUMMARY }                            from './nf_modules/bismark2summary.mod.nf'
+
+// Adding singlecell flag for scBS-seq processing
+include { BISMARK_METHYLATION_EXTRACTOR }                from './nf_modules/bismark_methylation_extractor.mod.nf'   params(singlecell: true, nonCG: true)
+include { COVERAGE2CYTOSINE }                          from './nf_modules/coverage2cytosine.mod.nf' params(nome: true, genome: genome)
+include { MULTIQC }                                     from './nf_modules/multiqc.mod.nf' 
 
 file_ch = makeFilesChannel(args)
 
@@ -99,4 +97,22 @@ workflow {
         BISMARK2REPORT                   (bismark_report_ch, params.outdir, params.bismark2report_args, params.verbose)
         BISMARK2SUMMARY                  (bismark_report_ch, params.outdir, params.bismark2summary_args, params.verbose)
         MULTIQC                          (multiqc_ch, params.outdir, params.multiqc_args, params.verbose)
+}
+
+// Since workflows with very long command lines tend to fail to get rendered at all, I was experimenting with a
+// minimal execution summary report so we at least know what the working directory was...
+workflow.onComplete {
+
+    def msg = """\
+        Pipeline execution summary
+        ---------------------------
+        Completed at: ${workflow.complete}
+        Duration    : ${workflow.duration}
+        Success     : ${workflow.success}
+        workDir     : ${workflow.workDir}
+        exit status : ${workflow.exitStatus}
+        """
+    .stripIndent()
+
+    sendMail(to: "${workflow.userName}@babraham.ac.uk", subject: 'Minimal pipeline execution report', body: msg)
 }

--- a/nf_chipseq
+++ b/nf_chipseq
@@ -69,3 +69,20 @@ workflow {
         MULTIQC                          (multiqc_ch, params.outdir, params.multiqc_args, params.verbose)
 }
 
+// Since workflows with very long command lines tend to fail to get rendered at all, I was experimenting with a
+// minimal execution summary report so we at least know what the working directory was...
+workflow.onComplete {
+
+    def msg = """\
+        Pipeline execution summary
+        ---------------------------
+        Completed at: ${workflow.complete}
+        Duration    : ${workflow.duration}
+        Success     : ${workflow.success}
+        workDir     : ${workflow.workDir}
+        exit status : ${workflow.exitStatus}
+        """
+    .stripIndent()
+
+    sendMail(to: "${workflow.userName}@babraham.ac.uk", subject: 'Minimal pipeline execution report', body: msg)
+}

--- a/nf_fastqc
+++ b/nf_fastqc
@@ -24,3 +24,21 @@ workflow {
         FASTQC(file_ch, params.outdir, params.fastqc_args, params.verbose)
        
 }
+
+// // Since workflows with very long command lines tend to fail to get rendered at all, I was experimenting with a
+// // minimal execution summary report so we at least know what the working directory was...
+// workflow.onComplete {
+
+//     def msg = """\
+//         Pipeline execution summary
+//         ---------------------------
+//         Completed at: ${workflow.complete}
+//         Duration    : ${workflow.duration}
+//         Success     : ${workflow.success}
+//         workDir     : ${workflow.workDir}
+//         exit status : ${workflow.exitStatus}
+//         """
+//     .stripIndent()
+
+//     sendMail(to: "${workflow.userName}@babraham.ac.uk", subject: 'Minimal pipeline execution report', body: msg)
+// }

--- a/nf_modules/bismark.mod.nf
+++ b/nf_modules/bismark.mod.nf
@@ -12,9 +12,15 @@ process BISMARK {
 
 	// TODO: Fix memory requirements, probably with error handling...
 	//label 'hugeMem'
-	label 'mem40G'
+
+	cpus { 5 }
+  	memory { 20.GB * task.attempt }  
+	errorStrategy { sleep(Math.pow(2, task.attempt) * 30 as long); return 'retry' }
+  	maxRetries 3
+	
+	// label 'mem40G'
 	// label 'multiCore'
-	label 'quadCore'
+	// label 'quadCore'
 		
     input:
 	    tuple val(name), path(reads)
@@ -42,10 +48,9 @@ process BISMARK {
 		bismark_options = bismark_args
 		if (params.singlecell){
 			bismark_options += " --non_directional "
-			// label 'multiCore'
 		}
 		else{
-			// label 'quadCore'
+		
 		}
 		
 		if (params.pbat){

--- a/nf_modules/bismark_deduplication.mod.nf
+++ b/nf_modules/bismark_deduplication.mod.nf
@@ -1,15 +1,15 @@
-nextflow.preview.dsl=2
+nextflow.enable.dsl=2
 
 process BISMARK_DEDUPLICATION {
-	label 'hugeMem'
+	
 	tag "$bam" // Adds name to job submission instead of (1), (2) etc.
 
-	// consider dynamic directive to increase memory
-	// memory { 2.GB * task.attempt }
-    // time { 1.hour * task.attempt }
-    // errorStrategy { task.exitStatus in 137..140 ? 'retry' : 'terminate' }
-    // maxRetries 3
-
+	// dynamic directive to increase memory as required
+	cpus = 1
+	memory { 20.GB * task.attempt }  
+	errorStrategy { sleep(Math.pow(2, task.attempt) * 30 as long); return 'retry' }
+  	maxRetries 5
+  	
     input:
 	    path(bam)
 		val (outputdir)

--- a/nf_modules/bismark_methylation_extractor.mod.nf
+++ b/nf_modules/bismark_methylation_extractor.mod.nf
@@ -1,4 +1,4 @@
-nextflow.preview.dsl=2
+nextflow.enable.dsl=2
 
 params.singlecell = false
 params.rrbs       = false
@@ -7,8 +7,9 @@ params.pbat       = false
 params.nonCG      = false
 
 process BISMARK_METHYLATION_EXTRACTOR {
-	label 'bigMem'
-	label 'multiCore'
+	label 'bigMem'          // 20G
+	label 'quadCore'        // 4 cores
+	
 	tag "$bam" // Adds name to job submission instead of (1), (2) etc.
 
     input:

--- a/nf_modules/coverage2cytosine.mod.nf
+++ b/nf_modules/coverage2cytosine.mod.nf
@@ -1,4 +1,4 @@
-nextflow.preview.dsl=2
+nextflow.enable.dsl=2
 
 params.singlecell = false
 params.rrbs       = false
@@ -9,8 +9,12 @@ params.nome       = false
 genome = params.genome["bismark"]
 
 process COVERAGE2CYTOSINE {
-	label 'hugeMem'
 	tag "$coverage_file" // Adds name to job submission instead of (1), (2) etc.
+
+	// dynamic directive
+	memory { 20.GB * task.attempt }  
+	errorStrategy { sleep(Math.pow(2, task.attempt) * 20 as long); return 'retry' }
+	maxRetries 5
 
     input:
 	    path(coverage_file)

--- a/nf_modules/fastq_screen.mod.nf
+++ b/nf_modules/fastq_screen.mod.nf
@@ -7,9 +7,13 @@ process FASTQ_SCREEN {
 	tag "$name" // Adds name to job submission instead of (1), (2) etc.
 
 	// label 'hugeMem'
-	// memory = "100.G"
+	
 	label 'multiCore'
-
+	
+	memory { 30.GB * task.attempt }  
+	errorStrategy { sleep(Math.pow(2, task.attempt) * 30 as long); return 'retry' }
+  	maxRetries 3
+  	
     input:
 	    tuple val(name), path(reads)
 		val (outputdir)

--- a/nf_modules/multiqc.mod.nf
+++ b/nf_modules/multiqc.mod.nf
@@ -2,8 +2,12 @@ nextflow.enable.dsl=2
 
 process MULTIQC {
 	
-	// label 'bigMem'
-	// label 'multiCore'
+	label 'quadCore'
+
+	// dynamic directive
+	memory { 20.GB * task.attempt }  
+	errorStrategy { sleep(Math.pow(2, task.attempt) * 30 as long); return 'retry' }
+	maxRetries 3
 
     input:
 	    path (file)

--- a/nf_modules/trim_galore.mod.nf
+++ b/nf_modules/trim_galore.mod.nf
@@ -11,8 +11,15 @@ params.three_prime_clip_R2 = ''
 
 process TRIM_GALORE {	
     
-	tag "$name" // Adds name to job submission instead of (1), (2) etc.
+	tag "$name"                         // Adds name to job submission instead of (1), (2) etc.
 
+	label 'quadCore'                    // sets cpus = 4
+	
+	// dynamic directive
+	memory { 10.GB * task.attempt }  
+	errorStrategy { sleep(Math.pow(2, task.attempt) * 30 as long); return 'retry' }
+	maxRetries 2
+    
 	input:
 	    tuple val (name), path (reads)
 		val (outputdir)

--- a/nf_qc
+++ b/nf_qc
@@ -38,3 +38,20 @@ workflow {
         MULTIQC                          (multiqc_ch, params.outdir, params.multiqc_args, params.verbose)
 
 }
+// Since workflows with very long command lines tend to fail to get rendered at all, I was experimenting with a
+// minimal execution summary report so we at least know what the working directory was...
+workflow.onComplete {
+
+    def msg = """\
+        Pipeline execution summary
+        ---------------------------
+        Completed at: ${workflow.complete}
+        Duration    : ${workflow.duration}
+        Success     : ${workflow.success}
+        workDir     : ${workflow.workDir}
+        exit status : ${workflow.exitStatus}
+        """
+    .stripIndent()
+
+    sendMail(to: "${workflow.userName}@babraham.ac.uk", subject: 'Minimal pipeline execution report', body: msg)
+}

--- a/nf_rnaseq
+++ b/nf_rnaseq
@@ -65,3 +65,20 @@ workflow {
         MULTIQC                          (multiqc_ch, params.outdir, params.multiqc_args, params.verbose)
 }
 
+// Since workflows with very long command lines tend to fail to get rendered at all, I was experimenting with a
+// minimal execution summary report so we at least know what the working directory was...
+workflow.onComplete {
+
+    def msg = """\
+        Pipeline execution summary
+        ---------------------------
+        Completed at: ${workflow.complete}
+        Duration    : ${workflow.duration}
+        Success     : ${workflow.success}
+        workDir     : ${workflow.workDir}
+        exit status : ${workflow.exitStatus}
+        """
+    .stripIndent()
+
+    sendMail(to: "${workflow.userName}@babraham.ac.uk", subject: 'Minimal pipeline execution report', body: msg)
+}


### PR DESCRIPTION
- changed some modules to retry with increased memory of process fails. This includes `FastQ Screen`, `Bismark`, `deduplicate_bismark` and `coverage2cytosine`

- removed some `withName` directives
- added a minimal email notification message for some pipelines. This might be helpful when the standard notification email doesn't get rendered at all because our tendency to submit `*fastq.gz` generates command lines that are longer than 8000 characters 