### PR TITLE
Update some pipelines

### DIFF
--- a/genomes.d/SIRV_ERCC.genome
+++ b/genomes.d/SIRV_ERCC.genome
@@ -1,0 +1,5 @@
+name	SIRV_ERCC
+species	SIRV_ERCC
+fasta	/bi/scratch/Genomes/SIRV_reference/
+bowtie2	/bi/scratch/Genomes/SIRV_reference/SIRV_ERCC
+hisat2	/bi/scratch/Genomes/SIRV_reference/SIRV_ERCC

--- a/nf_cellranger
+++ b/nf_cellranger
@@ -149,7 +149,7 @@ def helpMessage() {
 
     USAGE:
     
-    nf_cellranger [options] --genome <genomeID> --sample='sampleID' --fastqs='/path/to/FastQs/'
+    nf_cellranger [options] --genome <genomeID> --sample='sampleID' --fastqs_dir='/path/to/FastQs/'
     
     Mandatory arguments:
     ====================

--- a/nf_modules/bismark2summary.mod.nf
+++ b/nf_modules/bismark2summary.mod.nf
@@ -1,4 +1,5 @@
 nextflow.enable.dsl=2
+params.prefix = "" 
 
 process BISMARK2SUMMARY {
     
@@ -24,9 +25,18 @@ process BISMARK2SUMMARY {
 			println ("[MODULE] BISMARK2SUMMARY ARGS: " + bismark2summary_args)
 		}
 
-		"""
-		module load bismark
-		bismark2summary
-		"""
-
+		if (params.prefix == ""){
+			"""
+			module load bismark
+			bismark2summary
+			"""
+		}
+		else{
+			"""
+			module load bismark
+			bismark2summary
+			mv bismark_summary_report.txt  ${params.prefix}bismark_summary_report.txt 
+			mv bismark_summary_report.html ${params.prefix}bismark_summary_report.html
+			"""
+		}
 }

--- a/nf_modules/multiqc.mod.nf
+++ b/nf_modules/multiqc.mod.nf
@@ -1,5 +1,9 @@
 nextflow.enable.dsl=2
 
+// let's use an empty default prefix which can be set for each of the pipelines invoking MultiQC
+// using --prefix, e.g. "--prefix lane8075_L001_" so that we can copy files using 'copy_back_files'. 
+params.prefix = "" 
+
 process MULTIQC {
 	
 	label 'quadCore'
@@ -17,20 +21,19 @@ process MULTIQC {
 
 	output:
 	    path "*html",       emit: html
-		// path "*stats.txt", emit: stats 
-
+		
 	publishDir "$outputdir",
 		mode: "link", overwrite: true
 
-    script:
+	script:
+
 		
 		if (verbose){
 			println ("[MODULE] MULTIQC ARGS: " + multiqc_args)
 		}
-
+	
 		"""
 		module load multiqc
-		multiqc $multiqc_args -x work .
+		multiqc $multiqc_args -x work --filename ${params.prefix}multiqc_report.html .
 		"""
-
 }


### PR DESCRIPTION
This includes a new option `--prefix` to be added for MultiQC and Bismark Summary Reports, e.g. `--prefix lane7891_L001_` would result in:

```
lane7891_L001_multiqc_report.html
lane7891_L001_bismark_summary_report.txt
lane7891_L001_bismark_summary_report.txt
```

which can be copied back to seemlessly.